### PR TITLE
Reprojected image NaN if no valid pixels in footprint

### DIFF
--- a/src/dfreproject/reproject.py
+++ b/src/dfreproject/reproject.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Tuple, Union, Optional
 
 import numpy as np
@@ -5,14 +6,15 @@ import torch
 from astropy.io.fits import PrimaryHDU, Header
 from astropy.wcs import WCS
 
-
 from .sip import (
     apply_inverse_sip_distortion,
     apply_sip_distortion,
     get_sip_coeffs
 )
-
 from .utils import get_device
+
+
+logger = logging.getLogger(__name__)
 
 EPSILON = 1e-10
 VALID_ORDERS = ['bicubic', 'bilinear', 'nearest', 'nearest-neighbors']
@@ -515,9 +517,7 @@ class Reproject:
                 resampled_image[valid_pixels] / resampled_footprint[valid_pixels]
             )
         else:
-            print("WARNING: No valid pixels found in footprint!")
-            # FALLBACK: Use raw interpolated values without footprint correction
-            print("Fallback: Using raw interpolated values")
+            logger.warning("No valid pixels found in footprint! Using raw interpolated values")
 
         return result
 

--- a/src/dfreproject/reproject.py
+++ b/src/dfreproject/reproject.py
@@ -518,7 +518,6 @@ class Reproject:
             print("WARNING: No valid pixels found in footprint!")
             # FALLBACK: Use raw interpolated values without footprint correction
             print("Fallback: Using raw interpolated values")
-            result = resampled_image
 
         return result
 

--- a/src/dfreproject/utils.py
+++ b/src/dfreproject/utils.py
@@ -1,4 +1,9 @@
+import logging
+
 import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_device():
@@ -17,6 +22,5 @@ def get_device():
         else:
             return torch.device("cpu")
     except Exception as e:
-        print(f"CUDA error detected: {e}")
-        print("Falling back to CPU.")
+        logger.warning(f"CUDA error: {e}. Falling back to CPU.")
         return torch.device("cpu")


### PR DESCRIPTION
When no valid pixels, the original array instead of the NaN-filled array was being returned. Also added in some logging.