### PR TITLE
change 'reprojection' to 'dfreproject' in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install -e ".[docs]"
 ```python
 from astropy.io import fits
 from astropy.wcs import WCS
-from reprojection import calculate_reprojection
+from dfreproject import calculate_reprojection
 
 # Load source and target images
 source_hdu = fits.open('source_image.fits')[0]
@@ -92,7 +92,7 @@ In another scenario, it may be more adventageous to use an array of data and the
 ```python
 from astropy.io import fits
 from astropy.wcs import WCS
-from reprojection import calculate_reprojection
+from dfreproject import calculate_reprojection
 
 # Load source and target images
 source_hdu = fits.open('source_image.fits')[0]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,7 +58,7 @@ You can quickly run `dfreproject` with the following:
 
 
 
-If you use this pacakge, please cite our Zenodo DOI:
+If you use this package, please cite our Zenodo DOI:
 
 https://doi.org/10.5281/zenodo.15170605
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
 .. AstroReproject documentation master file
 
-Welcome to reprojection's documentation!
+Welcome to dfreproject's documentation!
 ========================================
 
 .. image:: https://codecov.io/gh/DragonflyTelescope/dfreproject/graph/badge.svg?token=409E407TN5
@@ -13,7 +13,7 @@ Welcome to reprojection's documentation!
     :target: https://dfreproject.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-Reprojection is a Python package for reprojecting astronomical images. The code runs using torch in order to speed up calculations.
+dfreproject is a Python package for reprojecting astronomical images. The code runs using torch in order to speed up calculations.
 
 The idea behind this package was to make a stripped down version of the `reproject` package affiliated with astropy in order to reduce computational time.
 We achieve approximately 20X faster computations with this package using the GPU and 10X using the CPU for images taken by the Dragonfly Telephoto Array. Take a look at the demos for an example.
@@ -37,7 +37,7 @@ You can quickly run `dfreproject` with the following:
 
     from astropy.io import fits
     from astropy.wcs import WCS
-    from reprojection import calculate_reprojection
+    from dfreproject import calculate_reprojection
 
     # Load source and target images
     source_hdu = fits.open('source_image.fits')[0]


### PR DESCRIPTION
There are three instances referring to `reprojection` instead of `dfreproject`

https://github.com/DragonflyTelescope/dfreproject/blob/91ea1d1a6688ed046e7ebc27e27a563cae40d1cb/README.md?plain=1#L64
https://github.com/DragonflyTelescope/dfreproject/blob/91ea1d1a6688ed046e7ebc27e27a563cae40d1cb/README.md?plain=1#L95
https://github.com/DragonflyTelescope/dfreproject/blob/91ea1d1a6688ed046e7ebc27e27a563cae40d1cb/docs/source/index.rst?plain=1#L40

plus the overall package name in index.rst